### PR TITLE
Fix unused warning variable which was treated as error when building kernel

### DIFF
--- a/drivers/media/i2c/cam_sensor/cam_imx219.c
+++ b/drivers/media/i2c/cam_sensor/cam_imx219.c
@@ -1070,6 +1070,8 @@ int imx219_probe(struct i2c_client *client, struct gpio_desc	*enable_gpio)
 	char facing[2];
 	int ret;
 
+	/* Ignore current device node since it is unused */
+	(void) node;
 	dev_info(dev, "driver version: %02x.%02x.%02x",
 		DRIVER_VERSION >> 16,
 		(DRIVER_VERSION & 0xff00) >> 8,


### PR DESCRIPTION
The device node variable **"struct device_node \*node = dev->of_node;"** currently is defined but not used. So the compiler detected the unused variable and triggered a warning **-Wunused-variable** and it is set as forbidden which causing the error consequently. 
![Screenshot from 2025-02-09 10-18-29](https://github.com/user-attachments/assets/a8459f31-5f74-4947-ad18-3fed1d86b5f6)
